### PR TITLE
Support for unique ids when referencing paths

### DIFF
--- a/src/svg-inject.js
+++ b/src/svg-inject.js
@@ -47,7 +47,8 @@
     marker: ['marker', 'marker-end', 'marker-mid', 'marker-start'],
     mask: NULL,
     pattern: ['fill', 'stroke'],
-    radialGradient: ['fill', 'stroke']
+    radialGradient: ['fill', 'stroke'],
+    path: NULL
   };
   var INJECTED = 1;
   var FAIL = 2;
@@ -219,6 +220,13 @@
               element[_SET_ATTRIBUTE_](propertyName, newValue);
             }
           }
+
+          ['xlink:href', 'href'].forEach(function(refAttrName) {
+            var iri = element[_GET_ATTRIBUTE_](refAttrName);
+            if (/^\s*#/.test(iri) && iri.indexOf(idSuffix) < 0) {
+              element[_SET_ATTRIBUTE_](refAttrName, iri.trim() + idSuffix); 
+            }
+          });
         }
         element = descElements[++i];        
       }


### PR DESCRIPTION
Fixes #29 

Pretty simple change, <path> tags are included in the suffix pass and `xlink:href` and `href` are updated accordingly. The basic and performance tests pass for me locally, the fallback tests fail but they also fail on the current master branch? Not sure what's going on there.