### PR TITLE
Change makeIdsUnique to convert all IDs by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Additionally, after loading the SVG, the value of the `src` attribute of the `<i
 | ------------- | ---- | ------- | ----------- |
 | useCache | boolean | `true` | If set to `true` the SVG will be cached using the absolute URL. The cache only persists for the lifetime of the page. Without caching images with the same absolute URL will trigger a new XMLHttpRequest but browser caching will still apply. |
 | copyAttributes | boolean | `true` | If set to `true` [attributes will be copied](#how-are-attributes-handled) from the `img` to the injected `svg` element. You may implement your own method for copying attributes in the `beforeInject` options hook. |
-| makeIdsUnique | boolean | `true` | If set to `true` all IDs of elements in the SVG are made unique by appending the string "--inject-X", where X is a running number which increases with each injection. This is done to avoid duplicate IDs in the DOM. |
+| makeIdsUnique | boolean/String | `true` | If set to `true` all IDs of elements in the SVG are made unique by appending the string "--inject-X", where X is a running number which increases with each injection. This is done to avoid duplicate IDs in the DOM. If set to `'onlyReferenced'`, only IDs referenced from inside the SVG will be made unique. If set to `false`, no IDs will be made unique.|
 | beforeLoad | function(img) | `undefined` | Hook before SVG is loaded. The `img` element is passed as a parameter. If the hook returns a string it is used as the URL instead of the `img` element's `src` attribute. |
 | afterLoad | function(svg,&nbsp;svgString) | `undefined` | Hook after SVG is loaded. The loaded `svg` element and `svgString` string are passed as a parameters. If caching is active this hook will only get called once for injected SVGs with the same absolute path. Changes to the `svg` element in this hook will be applied to all injected SVGs with the same absolute path. It's also possible to return an new SVG string or SVG element which will then be used for later injections. |
 | beforeInject | function(img,&nbsp;svg) | `undefined` | Hook directly before the SVG is injected. The `img` and `svg` elements are passed as parameters. The hook is called for every injected SVG. If an [Element](https://developer.mozilla.org/de/docs/Web/API/Element) is returned it gets injected instead of applying the default SVG injection. |
@@ -347,7 +347,7 @@ This example shows how to use SVGInject directly from Javascript without the `on
 
 Full support for all modern browsers, and IE9+ ([full list](https://caniuse.com/#feat=svg))
 
-Support for IE8 and IE7 with optional [PNG fallback method](https://github.com/iconfu/svg-inject/wiki/Fallback-solutions#fallback-for-no-svg-support-ie-78)
+Support for legacy browsers with optional [PNG fallback method](https://github.com/iconfu/svg-inject/wiki/Fallback-solutions#fallback-for-no-svg-support-ie-78)
 
 
 ## License

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ For most use cases this approach is recommended and provides nice [advantages](#
 
 * **Fallback if image source is not available**: Behaves like a normal `<img>` element if file not found or not available.
 
-* **Prevention of ID conflicts**: IDs used internally in the SVG are made unique before injection to prevent ID conflicts in the DOM
+* **Prevention of ID conflicts**: IDs in the SVG are made unique before injection to prevent ID conflicts in the DOM.
 
 
 ## What are additional advantages when using `onload`?
@@ -180,7 +180,7 @@ Additionally, after loading the SVG, the value of the `src` attribute of the `<i
 | ------------- | ---- | ------- | ----------- |
 | useCache | boolean | `true` | If set to `true` the SVG will be cached using the absolute URL. The cache only persists for the lifetime of the page. Without caching images with the same absolute URL will trigger a new XMLHttpRequest but browser caching will still apply. |
 | copyAttributes | boolean | `true` | If set to `true` [attributes will be copied](#how-are-attributes-handled) from the `img` to the injected `svg` element. You may implement your own method for copying attributes in the `beforeInject` options hook. |
-| makeIdsUnique | boolean | `true` | If set to `true` the id of elements in the `<defs>` element that can be references by property values (for example 'clipPath') are made unique by appending the string "--inject-X", where X is a running number which increases with each injection. This is done to avoid duplicate ids in the DOM. |
+| makeIdsUnique | boolean | `true` | If set to `true` all IDs of elements in the SVG are made unique by appending the string "--inject-X", where X is a running number which increases with each injection. This is done to avoid duplicate IDs in the DOM. |
 | beforeLoad | function(img) | `undefined` | Hook before SVG is loaded. The `img` element is passed as a parameter. If the hook returns a string it is used as the URL instead of the `img` element's `src` attribute. |
 | afterLoad | function(svg,&nbsp;svgString) | `undefined` | Hook after SVG is loaded. The loaded `svg` element and `svgString` string are passed as a parameters. If caching is active this hook will only get called once for injected SVGs with the same absolute path. Changes to the `svg` element in this hook will be applied to all injected SVGs with the same absolute path. It's also possible to return an new SVG string or SVG element which will then be used for later injections. |
 | beforeInject | function(img,&nbsp;svg) | `undefined` | Hook directly before the SVG is injected. The `img` and `svg` elements are passed as parameters. The hook is called for every injected SVG. If an [Element](https://developer.mozilla.org/de/docs/Web/API/Element) is returned it gets injected instead of applying the default SVG injection. |

--- a/src/svg-inject.js
+++ b/src/svg-inject.js
@@ -520,6 +520,7 @@
           var absUrl = getAbsoluteUrl(src);
           var useCacheOption = options.useCache;
           var makeIdsUniqueOption = options.makeIdsUnique;
+          var makeOnlyReferencedIdsUnique = makeIdsUniqueOption === 'onlyReferenced';
 
           var setSvgLoadCacheValue = function(val) {
             if (useCacheOption) {
@@ -549,7 +550,7 @@
                     // IDs for the SVG string have not been made unique before. This may happen if previous
                     // injection of a cached SVG have been run with the option makedIdsUnique set to false
                     svgElem = buildSvgElement(svgString, false);
-                    hasUniqueIds = makeIdsUnique(svgElem);
+                    hasUniqueIds = makeIdsUnique(svgElem, makeOnlyReferencedIdsUnique);
 
                     loadValue[0] = hasUniqueIds;
                     loadValue[2] = hasUniqueIds && svgElemToSvgString(svgElem);
@@ -606,7 +607,7 @@
             if (svgElem instanceof SVGElement) {
               var hasUniqueIds = NULL;
               if (makeIdsUniqueOption) {
-                hasUniqueIds = makeIdsUnique(svgElem);
+                hasUniqueIds = makeIdsUnique(svgElem, makeOnlyReferencedIdsUnique);
               }
 
               if (useCacheOption) {

--- a/src/svg-inject.js
+++ b/src/svg-inject.js
@@ -142,61 +142,54 @@
 
   // This function appends a suffix to IDs of referenced elements in the <defs> in order to  to avoid ID collision
   // between multiple injected SVGs. The suffix has the form "--inject-X", where X is a running number which is
-  // incremented with each injection.  References to the IDs are adjusted accordingly.
+  // incremented with each injection. References to the IDs are adjusted accordingly.
   // We assume tha all IDs within the injected SVG are unique, therefore the same suffix can be used for all IDs of one
   // injected SVG.
   function makeIdsUnique(svgElem) {
     var idSuffix = ID_SUFFIX + uniqueIdCounter++;
+    // Regular expression for functional notations of an IRI references. This will find occurences in the form
+    // url(#anyId) or url("#anyId") (for Internet Explorer) and capture the referenced ID
+    var funcIriRegex = /url\("?#([a-zA-Z][\w:.-]*)"?\)/g;
     // Get all elements with an ID. The SVG spec recommends to put referenced elements inside <defs> elements, but
-    // this is a requirement, therefore we have to search for IDs in the whole SVG.
+    // this is not a requirement, therefore we have to search for IDs in the whole SVG.
     var idElements = svgElem.querySelectorAll('[id]');
     var idElem;
+    // An object containing referenced IDs  as keys is used if only referenced IDs should be uniquified.
+    // If this object does not exist, all IDs will be uniquified.
+    var referencedIds;
     var tagName;
     var iriTagNames = {};
     var iriProperties = [];
     var changed = false;
     var i, j;
 
-    for (i = 0; i < idElements[_LENGTH_]; i++) {
-      idElem = idElements[i];
-      tagName = idElem.localName; // Use non-namespaced tag name
-      // Make ID unique if tag name is IRI referenceable
-      if (tagName in IRI_TAG_PROPERTIES_MAP) {
-        changed = true;
-        iriTagNames[tagName] = 1;
-        // Add suffix to element's ID
-        idElem.id += idSuffix;
-        // Replace ids in xlink:ref and href attributes
-        ['xlink:href', 'href'].forEach(function(refAttrName) {
-          var iri = idElem[_GET_ATTRIBUTE_](refAttrName);
-          if (/^\s*#/.test(iri)) { // Check if iri is non-null and has correct format
-            idElem[_SET_ATTRIBUTE_](refAttrName, iri.trim() + idSuffix);
+    if (idElements[_LENGTH_]) {
+      // Make all IDs unique by adding the ID suffix and collect all encountered tag names
+      // that are IRI referenceable from properities.
+      for (i = 0; i < idElements[_LENGTH_]; i++) {
+        tagName = idElements[i].localName; // Use non-namespaced tag name
+        // Make ID unique if tag name is IRI referenceable
+        if (tagName in IRI_TAG_PROPERTIES_MAP) {
+          iriTagNames[tagName] = 1;
+        }
+      }
+      // Get all properties that are mapped to the found IRI referenceable tags
+      for (tagName in iriTagNames) {
+        (IRI_TAG_PROPERTIES_MAP[tagName] || [tagName]).forEach(function (mappedProperty) {
+          // Add mapped properties to array of iri referencing properties.
+          // Use linear search here because the number of possible entries is very small (maximum 11)
+          if (iriProperties.indexOf(mappedProperty) < 0) {
+            iriProperties.push(mappedProperty);
           }
         });
       }
-    }
-
-    // Get all properties that are mapped to the found tags
-    for (tagName in iriTagNames) {
-      (IRI_TAG_PROPERTIES_MAP[tagName] || [tagName]).forEach(function (mappedProperty) {
-        // Add mapped properties to array of iri referencing properties.
-        // Use linear search here because the number of possible entries is very small (maximum 11)
-        if (iriProperties.indexOf(mappedProperty) < 0) {
-          iriProperties.push(mappedProperty);
-        }
-      });
-    }
-
-    // Replace IDs with new IDs in all references
-    if (iriProperties[_LENGTH_]) {
-      // Add "style" to properties, because it may contain references in the form 'style="fill:url(#myFill)"'
-      iriProperties.push(_STYLE_);
-      // Regular expression for functional notations of an IRI references. This will find occurences in the form
-      // url(#anyId) or url("#anyId") (for Internet Explorer)
-      var funcIriRegex = /url\("?#([a-zA-Z][\w:.-]*)"?\)/g;
-      // Run through all elements of the SVG and replace IDs in references. 
-      // To get all descending elements, getElementsByTagName('*') seems to perform faster than querySelectorAll('*'). 
-      // Since svgElem.getElementsByTagName('*') does not return the svg element itself, we have to handle it separately.      
+      if (iriProperties[_LENGTH_]) {
+        // Add "style" to properties, because it may contain references in the form 'style="fill:url(#myFill)"'
+        iriProperties.push(_STYLE_);
+      }
+      // Run through all elements of the SVG and replace IDs in references.
+      // To get all descending elements, getElementsByTagName('*') seems to perform faster than querySelectorAll('*').
+      // Since svgElem.getElementsByTagName('*') does not return the svg element itself, we have to handle it separately.
       var descElements = svgElem[_GET_ELEMENTS_BY_TAG_NAME_]('*');
       var element = svgElem;
       var propertyName;
@@ -204,8 +197,14 @@
       var newValue;
       for (i = -1; element != null;) {
         if (element.localName == _STYLE_) {
+          // If element is a style element, replace IDs in all occurences of "url(#anyId)" in text content
           value = element.textContent;
-          newValue = value && value.replace(funcIriRegex, 'url(#$1' + idSuffix + ')');
+          newValue = value && value.replace(funcIriRegex, function(match, id) {
+            if (referencedIds) {
+              referencedIds[id] = 1;
+            }
+            return 'url(#' + id + idSuffix + ')';
+          });
           if (newValue !== value) {
             element.textContent = newValue;
           }
@@ -214,25 +213,53 @@
           for (j = 0; j < iriProperties[_LENGTH_]; j++) {
             propertyName = iriProperties[j];
             value = element[_GET_ATTRIBUTE_](propertyName);
-            newValue = value && value.replace(funcIriRegex, 'url(#$1' + idSuffix + ')');
+            newValue = value && value.replace(funcIriRegex, function(match, id) {
+              if (referencedIds) {
+                referencedIds[id] = 1;
+              }
+                return 'url(#' + id + idSuffix + ')';
+            });
             if (newValue !== value) {
               element[_SET_ATTRIBUTE_](propertyName, newValue);
             }
           }
+          // Replace IDs in xlink:ref and href attributes
+          ['xlink:href', 'href'].forEach(function(refAttrName) {
+            var iri = element[_GET_ATTRIBUTE_](refAttrName);
+            if (/^\s*#/.test(iri)) { // Check if iri is non-null and internal reference
+              iri = iri.trim();
+              element[_SET_ATTRIBUTE_](refAttrName, iri + idSuffix);
+              if (referencedIds) {
+                // Add ID to referenced IDs
+                referencedIds[iri.substring(1)] = 1;
+              }
+            }
+          });
         }
-        element = descElements[++i];        
+        element = descElements[++i];
+      }
+      for (i = 0; i < idElements[_LENGTH_]; i++) {
+        idElem = idElements[i];
+        // If set of referenced IDs exists, make only referenced IDs unique,
+        // otherwise make all IDs unique.
+        if (!referencedIds || referencedIds[idElem.id]) {
+          // Add suffix to element's ID
+          idElem.id += idSuffix;
+          changed = true;
+        }
       }
     }
-
     // return true if SVG element has changed
     return changed;
   }
 
-  // For cached SVGs the IDs are made unique by simply replacing the already inserted unique IDs with a 
+
+  // For cached SVGs the IDs are made unique by simply replacing the already inserted unique IDs with a
   // higher ID counter. This is much more performant than a call to makeIdsUnique().
   function makeIdsUniqueCached(svgString) {
     return svgString.replace(ID_SUFFIX_REGEX, ID_SUFFIX + uniqueIdCounter++);
   }
+
 
   // Inject SVG by replacing the img element with the SVG element in the DOM
   function inject(imgElem, svgElem, absUrl, options) {
@@ -306,7 +333,7 @@
         // DOMParser does not throw an exception, but instead puts parsererror tags in the document
         return NULL;
       }
-      return svgDoc.documentElement;  
+      return svgDoc.documentElement;
     } else {
       var div = document.createElement('div');
       div.innerHTML = svgStr;
@@ -320,6 +347,7 @@
     // make the element visible, not for removing the event listener.
     imgElem.removeAttribute('onload');
   }
+
 
   function errorMessage(msg) {
     console.error('SVGInject: ' + msg);
@@ -386,7 +414,7 @@
      * Options:
      * useCache: If set to `true` the SVG will be cached using the absolute URL. Default value is `true`.
      * copyAttributes: If set to `true` the attributes will be copied from `img` to `svg`. Dfault value
-     *     is `true.
+     *     is `true`.
      * makeIdsUnique: If set to `true` the ID of elements in the `<defs>` element that can be references by
      *     property values (for example 'clipPath') are made unique by appending "--inject-X", where X is a
      *     running number which increases with each injection. This is done to avoid duplicate IDs in the DOM.
@@ -417,7 +445,7 @@
           var onAllFinish = options.onAllFinish;
           if (onAllFinish) {
             onAllFinish();
-          }          
+          }
           resolve && resolve();
         };
 
@@ -434,7 +462,7 @@
                 allFinish();
               }
             };
-            
+
             for (var i = 0; i < injectCount; i++) {
               SVGInjectElement(img[i], options, finish);
             }
@@ -514,7 +542,7 @@
                 var svgString = loadValue[1];
                 var uniqueIdsSvgString = loadValue[2];
                 var svgElem;
-                
+
                 if (makeIdsUniqueOption) {
                   if (hasUniqueIds === NULL) {
                     // IDs for the SVG string have not been made unique before. This may happen if previous
@@ -531,7 +559,7 @@
                 }
 
                 svgElem = svgElem || buildSvgElement(svgString, false);
-                    
+
                 inject(imgElem, svgElem, absUrl, options);
               }
               onFinish();
@@ -548,7 +576,7 @@
               return;
             } else {
               var svgLoad = [];
-              // set property isCallbackQueue to Array to differentiate from array with cached loaded values  
+              // set property isCallbackQueue to Array to differentiate from array with cached loaded values
               svgLoad.isCallbackQueue = true;
               svgLoadCache[absUrl] = svgLoad;
             }
@@ -564,7 +592,7 @@
             if (afterLoad) {
               // Invoke afterLoad hook which may modify the SVG element. After load may also return a new
               // svg element or svg string
-              var svgElemOrSvgString = afterLoad(svgElem, svgString) || svgElem;              
+              var svgElemOrSvgString = afterLoad(svgElem, svgString) || svgElem;
               if (svgElemOrSvgString) {
                 // Update svgElem and svgString because of modifications to the SVG element or SVG string in
                 // the afterLoad hook, so the modified SVG is also used for all later cached injections

--- a/src/svg-inject.js
+++ b/src/svg-inject.js
@@ -145,7 +145,8 @@
   // incremented with each injection. References to the IDs are adjusted accordingly.
   // We assume tha all IDs within the injected SVG are unique, therefore the same suffix can be used for all IDs of one
   // injected SVG.
-  function makeIdsUnique(svgElem) {
+  // If the onlyReferenced argument is set to true, only those IDs will be made unique that are referenced from within the SVG
+  function makeIdsUnique(svgElem, onlyReferenced) {
     var idSuffix = ID_SUFFIX + uniqueIdCounter++;
     // Regular expression for functional notations of an IRI references. This will find occurences in the form
     // url(#anyId) or url("#anyId") (for Internet Explorer) and capture the referenced ID
@@ -156,7 +157,7 @@
     var idElem;
     // An object containing referenced IDs  as keys is used if only referenced IDs should be uniquified.
     // If this object does not exist, all IDs will be uniquified.
-    var referencedIds;
+    var referencedIds = onlyReferenced ? [] : NULL;
     var tagName;
     var iriTagNames = {};
     var iriProperties = [];
@@ -165,7 +166,7 @@
 
     if (idElements[_LENGTH_]) {
       // Make all IDs unique by adding the ID suffix and collect all encountered tag names
-      // that are IRI referenceable from properities.
+      // that are IRI referenceable from properities.     
       for (i = 0; i < idElements[_LENGTH_]; i++) {
         tagName = idElements[i].localName; // Use non-namespaced tag name
         // Make ID unique if tag name is IRI referenceable
@@ -195,7 +196,7 @@
       var propertyName;
       var value;
       var newValue;
-      for (i = -1; element != null;) {
+      for (i = -1; element != NULL;) {
         if (element.localName == _STYLE_) {
           // If element is a style element, replace IDs in all occurences of "url(#anyId)" in text content
           value = element.textContent;


### PR DESCRIPTION
In order to avoid duplicate IDs when injecting the same SVG multiple times, all IDs in the SVG have to be made unique. This is done now by default, also solving the issue that referenced from `use` elements were not converted.

Optionally only making the IDs that are referenced from inside the SVG can now be made unique by setting `makeIdsUnique` to `only Referenced`.