### PR TITLE
Added override for graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "gulp-uglify": "^3.0.0",
     "pump": "^3.0.0"
   },
+  "overrides": {
+    "graceful-fs": "^4.2.11"
+  },
   "bugs": {
     "url": "https://github.com/iconfu/svg-inject/issues"
   },


### PR DESCRIPTION
Running `npm install && npx gulp`, I get the following error:
```
fs.js:42
} = primordials;
    ^

ReferenceError: primordials is not defined
    at fs.js:42:5
    at req_ (/home/steeps/Documents/personal_projects/svg-inject/node_modules/natives/index.js:143:24)
    at Object.req [as require] (/home/steeps/Documents/personal_projects/svg-inject/node_modules/natives/index.js:55:10)
    at Object.<anonymous> (/home/steeps/Documents/personal_projects/svg-inject/node_modules/graceful-fs/fs.js:1:37)
    at Module._compile (node:internal/modules/cjs/loader:1254:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1308:10)
    at Module.load (node:internal/modules/cjs/loader:1117:32)
    at Module._load (node:internal/modules/cjs/loader:958:12)
    at Module.require (node:internal/modules/cjs/loader:1141:19)
    at require (node:internal/modules/cjs/helpers:110:18)

Node.js v18.16.0
```
This error occurs as `svg-inject` depends on `gulp@3.9.1`, which depends on `graceful-fs@^3.0.0`.  `graceful-fs@^3.0.0` monkey patches Node.js's `fs` module, but this stopped working after Node.js version 11.15.  `graceful-fs@^4.0.0` has been updated to work with more recent versions of Node.js, and the proposed pull request ensures this later version of the library is used. This fixes the above and allows `npm install && npx gulp` to run without error. 